### PR TITLE
Maybe fixed breaking api change?

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -113,7 +113,9 @@ func (a *Auth) handleLogOnResponse(packet *Packet) {
 	if result == EResult_OK {
 		atomic.StoreInt32(&a.client.sessionId, msg.Header.Proto.GetClientSessionid())
 		atomic.StoreUint64(&a.client.steamId, msg.Header.Proto.GetSteamid())
-		a.client.Web.webLoginKey = *body.WebapiAuthenticateUserNonce
+		if body.WebapiAuthenticateUserNonce != nil {
+			a.client.Web.webLoginKey = *body.WebapiAuthenticateUserNonce
+		}
 
 		go a.client.heartbeatLoop(time.Duration(body.GetOutOfGameHeartbeatSeconds()))
 


### PR DESCRIPTION
`WebapiAuthenticateUserNonce` is deprecated and therefore always nil resulting in a nil pointer deref.

This at least fixes the panic, not sure about which other features might get affected by this and a nicer fix is probably preferred. 